### PR TITLE
Update README.md to the correct usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dockerfile for [gogs](http://gogs.io) server(a self-hosted git service).
 
 ## Usage
 ```
-git pull codeskyblue/docker-gogs
+docker pull codeskyblue/docker-gogs
 
 mkdir /var/gogs
 docker run -d -p 22:22 -p 3000:3000 -v /var/gogs:/data codeskyblue/docker-gogs


### PR DESCRIPTION
The readme was telling users to do a `git pull`, when a `docker pull` is needed
