### PR TITLE
Upgrade to OpenSSH 6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM google/golang
 MAINTAINER codeskyblue@gmail.com
 
-RUN apt-get install -y openssh-server
+RUN echo "deb http://ftp.debian.org/debian/ wheezy-backports main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y -t wheezy-backports openssh-server
 
 # grab but do not build gogs
 RUN git clone https://github.com/gogits/gogs.git /gopath/src/github.com/gogits/gogs


### PR DESCRIPTION
The bundled OpenSSH (6.0) from the golang image doesn't support ed25519 keys.
This fix this by adding the backports repository to get the version 6.6.

**Before:**
```shell
ssh -V # OpenSSH_6.0p1
```

```
Sorry, we're not able to verify your SSH key: ssh-keygen -l -f: line 1 too long: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3o...
```

**After:**
```shell
ssh -V # OpenSSH_6.6.1p1
```

And it works in Gogs :-)