### PR TITLE
Unique ssh host keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,14 @@ RUN sed 's@UsePrivilegeSeparation yes@UsePrivilegeSeparation no@' -i /etc/ssh/ss
 RUN echo "export VISIBLE=now" >> /etc/profile
 RUN echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
 
+# create new server keys on startup
+RUN sed 's@^HostKey@\#HostKey@' -i /etc/ssh/sshd_config
+RUN echo "HostKey /data/ssh/ssh_host_key" >> /etc/ssh/sshd_config
+RUN echo "HostKey /data/ssh/ssh_host_rsa_key" >> /etc/ssh/sshd_config
+RUN echo "HostKey /data/ssh/ssh_host_dsa_key" >> /etc/ssh/sshd_config
+RUN echo "HostKey /data/ssh/ssh_host_ecdsa_key" >> /etc/ssh/sshd_config
+RUN echo "HostKey /data/ssh/ssh_host_ed25519_key" >> /etc/ssh/sshd_config
+
 # prepare data
 ENV GOGS_CUSTOM /data/gogs
 RUN echo "export GOGS_CUSTOM=/data/gogs" >> /etc/profile

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 #
 
-service ssh start
-
 if ! test -d /data/gogs
 then
 	mkdir -p /var/run/sshd
 	mkdir -p /data/gogs/data /data/gogs/conf /data/gogs/log /data/git
 fi
+
+if ! test -d /data/ssh
+then
+	mkdir /data/ssh
+	ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
+	ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
+	ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
+	ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
+	ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
+	su -c chown -R root:root /data/ssh/*
+	su -c chmod 600 /data/ssh/*
+fi
+
+service ssh start
 
 test -d /data/gogs/templates || cp -ar ./templates /data/gogs/
 

--- a/start.sh
+++ b/start.sh
@@ -15,8 +15,8 @@ then
 	ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
 	ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 	ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
-	su -c chown -R root:root /data/ssh/*
-	su -c chmod 600 /data/ssh/*
+	chown -R root:root /data/ssh/*
+	chmod 600 /data/ssh/*
 fi
 
 service ssh start


### PR DESCRIPTION
At the moment every deployment of the docker-gogs container is identifying with the same SSH host keys. Therefore a MITM attack is possible as the host keys can be easily pulled from the image.

The pull request would allow for the generation of deployment specific SSH host keys.
Starting the container would cause all current known_hosts entries to be invalidated as every docker container gets its own unique host keys. I don't know if its possible to add a warning to the container update